### PR TITLE
fix jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,13 +53,14 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
+            <version>1.35</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <classifier>tests</classifier>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>1.35</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a tests classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
jenkinsci/bom#164

Note: We'll need a release for PCT please